### PR TITLE
Parse new rev format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,15 +45,16 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3abb7553d5b9b8421c6de7cb02606ff15e0c6eea7d8eadd75ef013fd636bec36"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -96,7 +97,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -319,7 +320,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
  "version_check",
 ]
 
@@ -336,18 +337,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
@@ -414,7 +415,7 @@ checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -446,6 +447,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +478,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-cargo_metadata = "0.15"
+cargo_metadata = "0.18.1"
 indexmap = "1.9.1"
 tempfile = "3.3.0"
 git2 = "0.16.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ struct Cli {
     manifest_path: String,
 }
 
-#[derive(Eq, Hash, PartialEq, Debug)]
+#[derive(Eq, Hash, PartialEq, Debug, Clone)]
 struct GitRepo {
     url: String,
     rev: Option<String>,
@@ -210,7 +210,8 @@ fn main() {
 
     let git_list: IndexSet<GitRepo> = git_list
         .iter()
-        .filter_map(|git_repo| {
+        .cloned()
+        .map(|git_repo| {
             let protocol: Vec<_> = git_repo.url.split("://").collect();
             let folder = get_repo_folder_name(protocol[1].to_string());
             println!(
@@ -224,14 +225,14 @@ fn main() {
                 .clone(&git_repo.url, Path::new(&folder))
                 .expect("failed to clone repository");
 
-            let spec = match git_repo {
+            let spec = match &git_repo {
                 GitRepo { rev: Some(rev), .. } => rev.clone(),
                 GitRepo { tag: Some(tag), .. } => format!("refs/tags/{}", tag),
                 GitRepo {
                     branch: Some(branch),
                     ..
                 } => format!("refs/remotes/origin/{}", branch),
-                _ => return None,
+                _ => return git_repo,
             };
 
             let obj = repo.revparse_single(&spec).unwrap();
@@ -258,12 +259,12 @@ fn main() {
                 }
             }
 
-            Some(GitRepo {
+            GitRepo {
                 url: git_repo.url.clone(),
                 rev: Some(obj.id().to_string()),
                 branch: git_repo.branch.clone(),
                 tag: git_repo.tag.clone(),
-            })
+            }
         })
         .collect();
     dir.close().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use cargo_metadata::CargoOpt;
 
 use clap::Parser;
-use git2::{Cred, Oid, RemoteCallbacks};
+use git2::{Cred, RemoteCallbacks};
 use glob::glob;
 use indexmap::IndexSet;
 use tempfile::tempdir;
@@ -20,10 +20,12 @@ struct Cli {
     manifest_path: String,
 }
 
-#[derive(Eq, Hash, PartialEq)]
+#[derive(Eq, Hash, PartialEq, Debug)]
 struct GitRepo {
     url: String,
-    commit: String,
+    rev: Option<String>,
+    tag: Option<String>,
+    branch: Option<String>,
 }
 
 fn dump_metadata(
@@ -79,7 +81,12 @@ fn dump_metadata(
                 } else {
                     commit = elements[1].to_owned();
                 }
-                let git_repo = GitRepo { url, commit };
+                let git_repo = GitRepo {
+                    url,
+                    rev: Some(commit),
+                    branch: None,
+                    tag: None,
+                };
                 git.insert(git_repo);
             } else {
                 println!("[not handled] {}", iter[2]);
@@ -108,13 +115,38 @@ fn dump_metadata(
                 let repository: Vec<_> = repo[1].split('?').collect();
                 let url: String = repository[0].to_owned();
                 let elements: Vec<_> = repository[1].split('#').collect();
-                let commit;
+                let selector;
                 if elements.len() > 2 {
-                    commit = elements[1].to_owned();
+                    selector = elements[1].to_owned();
                 } else {
-                    commit = elements[0].to_owned();
+                    selector = elements[0].to_owned();
                 }
-                let git_repo = GitRepo { url, commit };
+                let git_repo = match selector.split("=").collect::<Vec<&str>>().as_slice() {
+                    ["rev", rev_name] => GitRepo {
+                        url,
+                        rev: Some(rev_name.to_string()),
+                        branch: None,
+                        tag: None,
+                    },
+                    ["tag", tag_name] => GitRepo {
+                        url,
+                        rev: None,
+                        branch: None,
+                        tag: Some(tag_name.to_string()),
+                    },
+                    ["branch", branch_name] => GitRepo {
+                        url,
+                        rev: None,
+                        branch: Some(branch_name.to_string()),
+                        tag: None,
+                    },
+                    _ => GitRepo {
+                        url,
+                        rev: None,
+                        branch: None,
+                        tag: None,
+                    },
+                };
                 git.insert(git_repo);
             } else {
                 println!("[not handled] {}", repr);
@@ -176,44 +208,64 @@ fn main() {
     let mut builder = git2::build::RepoBuilder::new();
     builder.fetch_options(fo);
 
-    for _git in git_list.iter() {
-        let protocol: Vec<_> = _git.url.split("://").collect();
-        let folder = get_repo_folder_name(protocol[1].to_string());
-        println!(
-            "    git://{};lfs=0;nobranch=1;protocol={};destsuffix={};name={} \\",
-            protocol[1], protocol[0], folder, folder
-        );
+    let git_list: IndexSet<GitRepo> = git_list
+        .iter()
+        .filter_map(|git_repo| {
+            let protocol: Vec<_> = git_repo.url.split("://").collect();
+            let folder = get_repo_folder_name(protocol[1].to_string());
+            println!(
+                "    git://{};lfs=0;nobranch=1;protocol={};destsuffix={};name={} \\",
+                protocol[1], protocol[0], folder, folder
+            );
 
-        let sub_folder = get_repo_folder_name(_git.url.to_string());
-        let folder = dir.path().join(sub_folder);
-        let repo = builder
-            .clone(&_git.url, Path::new(&folder))
-            .expect("failed to clone repository");
+            let sub_folder = get_repo_folder_name(git_repo.url.to_string());
+            let folder = dir.path().join(sub_folder);
+            let repo = builder
+                .clone(&git_repo.url, Path::new(&folder))
+                .expect("failed to clone repository");
 
-        let oid = Oid::from_str(&_git.commit).unwrap();
-        let commit = repo.find_commit(oid).unwrap();
+            let spec = match git_repo {
+                GitRepo { rev: Some(rev), .. } => rev.clone(),
+                GitRepo { tag: Some(tag), .. } => format!("refs/tags/{}", tag),
+                GitRepo {
+                    branch: Some(branch),
+                    ..
+                } => format!("refs/remotes/origin/{}", branch),
+                _ => return None,
+            };
 
-        let _ = repo.branch(&_git.commit, &commit, false);
+            let obj = repo.revparse_single(&spec).unwrap();
 
-        let obj = repo
-            .revparse_single(&("refs/heads/".to_owned() + &_git.commit))
-            .unwrap();
+            let _ = repo.branch(
+                &format!("commit_{}", obj.id()),
+                &obj.as_commit().unwrap(),
+                false,
+            );
+            let _ = repo.checkout_tree(&obj, None);
+            let _ = repo.set_head(&format!("refs/heads/{}", obj.id()));
 
-        let _ = repo.checkout_tree(&obj, None);
-
-        let _ = repo.set_head(&("refs/heads/".to_owned() + &_git.commit));
-
-        let _glob = String::from(folder.join("**/Cargo.toml").to_string_lossy());
-        for entry in glob(&_glob).unwrap() {
-            match entry {
-                Ok(manifest) => {
-                    let mut _git_list = IndexSet::new();
-                    let _ = dump_metadata(manifest, &mut crate_list, &mut _git_list);
+            let _glob = String::from(folder.join("**/Cargo.toml").to_string_lossy());
+            for entry in glob(&_glob).unwrap() {
+                match entry {
+                    Ok(manifest) => {
+                        // creates are added recursively
+                        // git repos are only added at top-level
+                        // is that intentional?
+                        let mut _git_list = IndexSet::new();
+                        let _ = dump_metadata(manifest, &mut crate_list, &mut _git_list);
+                    }
+                    Err(e) => println!("Err: {:?}", e),
                 }
-                Err(e) => println!("Err: {:?}", e),
             }
-        }
-    }
+
+            Some(GitRepo {
+                url: git_repo.url.clone(),
+                rev: Some(obj.id().to_string()),
+                branch: git_repo.branch.clone(),
+                tag: git_repo.tag.clone(),
+            })
+        })
+        .collect();
     dir.close().unwrap();
     println!("\"\n");
 
@@ -221,7 +273,7 @@ fn main() {
         let protocol: Vec<_> = _git.url.split("://").collect();
         let folder = get_repo_folder_name(protocol[1].to_string());
         println!("SRCREV_FORMAT .= \"_{}\"", folder);
-        println!("SRCREV_{} = \"{}\"", folder, _git.commit);
+        println!("SRCREV_{} = \"{}\"", folder, _git.rev.clone().unwrap());
     }
 
     if !git_list.is_empty() {


### PR DESCRIPTION
- Parses new rev=xxxxxxx format.
- Bump cargo_metadata to parse version 4 lock format and accept 2024 edition.

# before 1.77

```
(git+https://github.com/jerel/serde-reflection?branch=membrane#06177ba68e39ec49e62cff7d0df46d10a2924008)
```

# after 1.77

```
git+https://github.com/jerel/serde-reflection?rev=06177ba#serde-reflection@0.25.1
```

# how to test

Make project that contains git source crate. Then set override 1.76 and 1.77.

```Cargo.toml
[package]
name = "sample_177"
version = "0.1.0"
edition = "2021"

[dependencies]
serde-reflection = { git = "https://github.com/jerel/serde-reflection", rev = "06177ba", version = "0.3.6" }
```

```
rustup override set 1.76
# or
rustup override set 1.77
``